### PR TITLE
feat: add v0.2.0 nodejs circuit breaker booster

### DIFF
--- a/circuit-breaker/nodejs/nodejs-circuit-breaker-booster.yaml
+++ b/circuit-breaker/nodejs/nodejs-circuit-breaker-booster.yaml
@@ -1,0 +1,2 @@
+githubRepo: bucharest-gold/nodejs-circuit-breaker
+gitRef: v0.2.0


### PR DESCRIPTION
This adds a tagged version of the NodeJS circuit breaker booster to the catalog.