### PR TITLE
Fix OBST-384 for Swarm 

### DIFF
--- a/configmap/wildfly-swarm/redhat/wildfly-swarm-configmap-redhat.yaml
+++ b/configmap/wildfly-swarm/redhat/wildfly-swarm-configmap-redhat.yaml
@@ -1,2 +1,2 @@
 githubRepo: wildfly-swarm-openshiftio-boosters/wfswarm-configmap
-gitRef: 7.0.0-redhat-2
+gitRef: 7.0.0-redhat-3


### PR DESCRIPTION
The configmap is created during s2i setup